### PR TITLE
Changes diff colors

### DIFF
--- a/snapshot.go
+++ b/snapshot.go
@@ -168,7 +168,7 @@ func DiffPrettyText(diffs []diffmatchpatch.Diff) string {
 				if unicode.IsSpace(c) {
 					_, _ = buff.WriteRune(c)
 				} else {
-					_, _ = buff.WriteString(color.New(color.BgGreen).Sprintf(string(c)))
+					_, _ = buff.WriteString(color.New(color.BgBlue, color.FgWhite).Sprintf(string(c)))
 				}
 			}
 		case diffmatchpatch.DiffEqual:


### PR DESCRIPTION
Makes diffs show as white foreground on blue background. Previous value was current foreground on green background. Because I have a green foreground, any diffs rendered as a solid green block.

Ideally this would be configurable, but since it's using fatih/color, it's not straightforward to add in and make flexible. Perhaps in a later PR.